### PR TITLE
Switch to ruamel for consistent float parsing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ setup(
     package_dir={"": "src"},
     packages=find_packages("src"),
     package_data={"": ["*.yaml"]},
-    install_requires=["pytest", "pyyaml"],
+    install_requires=["pytest", "ruamel.yaml"],
 )

--- a/src/spark_config/config.py
+++ b/src/spark_config/config.py
@@ -235,18 +235,26 @@ class Config:
         return f"{self.__class__.__name__}:\n{pprint.pformat(self.dump())}"
 
     @staticmethod
-    def load(cls, filepath, strict=True, warn_missing=False):
-        """Load an abitrary config from file."""
+    def load(cls, filepath, **kwargs):
+        """
+        Load an abitrary config from file.
+
+        Forwards **kwargs to `update`.
+        """
+        with pathlib.Path(filepath).open("r") as fin:
+            return Config.loads(cls, fin.read(), **kwargs)
+
+    @staticmethod
+    def loads(cls, contents: str, **kwargs):
+        """
+        Load an abitrary config from a string representation.
+
+        Forwards **kwargs to `update`.
+        """
         assert issubclass(cls, Config), f"{cls} is not a config!"
 
         instance = cls()
-        with pathlib.Path(filepath).open("r") as fin:
-            instance.update(
-                yaml.load(fin),
-                strict=strict,
-                warn_missing=warn_missing,
-            )
-
+        instance.update(yaml.load(contents), **kwargs)
         return instance
 
     def _parse_yaml_list(self, field, field_config, global_name, **kwargs):

--- a/src/spark_config/config.py
+++ b/src/spark_config/config.py
@@ -37,7 +37,10 @@ import pathlib
 import pprint
 import typing
 
-import yaml
+from ruamel.yaml import YAML
+
+yaml = YAML(typ="safe", pure=True)
+yaml.default_flow_style = False
 
 Logger = logging.getLogger(__name__)
 
@@ -166,7 +169,7 @@ class Config:
         """Dump a class to disk."""
         filepath = pathlib.Path(filepath)
         with filepath.open("w") as fout:
-            fout.write(yaml.safe_dump(self.dump()))
+            yaml.dump(self.dump(), fout)
 
     def update(self, config, strict=True, warn_missing=False, extend=True, _parent=""):
         """
@@ -239,7 +242,9 @@ class Config:
         instance = cls()
         with pathlib.Path(filepath).open("r") as fin:
             instance.update(
-                yaml.safe_load(fin), strict=strict, warn_missing=warn_missing
+                yaml.load(fin),
+                strict=strict,
+                warn_missing=warn_missing,
             )
 
         return instance

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,7 +36,6 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 import pytest
-import yaml
 
 import spark_config as sc
 
@@ -252,8 +251,7 @@ children:
 - {a: 2, b: 3, c: 4}
 - {}
 """
-    config = ListConfig()
-    config.update(yaml.safe_load(contents))
+    config = sc.Config.loads(ListConfig, contents)
     assert config.children == [Foo(a=1.0, b=2, c="3"), Foo(a=2.0, b=3, c="4"), Foo()]
 
 
@@ -266,8 +264,7 @@ children:
   child_c: {}
 """
 
-    config = ListConfig()
-    config.update(yaml.safe_load(contents))
+    config = sc.Config.loads(ListConfig, contents)
     assert config.children == [Foo(a=1.0, b=2, c="3"), Foo(a=2.0, b=3, c="4"), Foo()]
 
 
@@ -279,8 +276,7 @@ children:
   two: {a: 2, b: 3, c: 4}
   four: {}
 """
-    config = DictConfig()
-    config.update(yaml.safe_load(contents))
+    config = sc.Config.loads(DictConfig, contents)
     assert config.children == {
         "one": Foo(a=1.0, b=2, c="3"),
         "two": Foo(a=2.0, b=3, c="4"),
@@ -310,8 +306,7 @@ children:
 - {}
 """
 
-    config = DictConfig()
-    config.update(yaml.safe_load(contents))
+    config = sc.Config.loads(DictConfig, contents)
     assert config.children == {
         "0": Foo(a=1.0, b=2, c="3"),
         "1": Foo(a=2.0, b=3, c="4"),


### PR DESCRIPTION
ruamel dump takes the output file as an argument instead of returning a string; other than that pretty much a drop-in replacement for pyyaml