### PR TITLE
switch from logging to warnings

### DIFF
--- a/src/spark_config/__init__.py
+++ b/src/spark_config/__init__.py
@@ -1,11 +1,23 @@
 import importlib
 import pkgutil
+import re
 import warnings
 
 from spark_config.config import *
 
 
-def discover_plugins(plugin_prefix):
+def discover_plugins(plugin_prefix, skiplist=None):
+    """
+    Import all modules with that match the provided prefix.
+
+    Args:
+        plugin_prefix (str): Plugin prefix to match against
+        skiplist (Optional[List[str]]): List of plugins (regex supported) to skip
+
+    Returns:
+        All imported modules that match the prefix
+    """
+
     def _try_load(name):
         try:
             return importlib.import_module(name)
@@ -13,10 +25,11 @@ def discover_plugins(plugin_prefix):
             warnings.warn(f"Unable to load plugin '{name}': {e}")
             return None
 
-    discovered_plugins = {
-        name: _try_load(name)
-        for finder, name, ispkg in pkgutil.iter_modules()
-        if name.startswith(plugin_prefix)
-    }
+    names = [x for _, x, _ in pkgutil.iter_modules() if x.startswith(plugin_prefix)]
+    if skiplist is not None:
+        matcher = re.compile("|".join(skiplist))
+        names = [x for x in names if matcher.match(x) is None]
+
+    discovered_plugins = {name: _try_load(name) for name in names}
     discovered_plugins = {k: v for k, v in discovered_plugins.items() if v is not None}
     return discovered_plugins

--- a/src/spark_config/__init__.py
+++ b/src/spark_config/__init__.py
@@ -1,6 +1,6 @@
 import importlib
-import logging
 import pkgutil
+import warnings
 
 from spark_config.config import *
 
@@ -10,9 +10,7 @@ def discover_plugins(plugin_prefix):
         try:
             return importlib.import_module(name)
         except ImportError as e:
-            logging.getLogger("spark_config").warning(
-                f"Unable to load plugin '{name}': {e}"
-            )
+            warnings.warn(f"Unable to load plugin '{name}': {e}")
             return None
 
     discovered_plugins = {
@@ -22,6 +20,3 @@ def discover_plugins(plugin_prefix):
     }
     discovered_plugins = {k: v for k, v in discovered_plugins.items() if v is not None}
     return discovered_plugins
-
-
-# TOOD(nathan) register discovered


### PR DESCRIPTION
Decided that it was better to use the `warnings` module when discovering plugins versus `logging` so that I can hide warnings about invalid packages (and also adds ability to filter packages by regex)